### PR TITLE
Add Dockerfile for Django project setup and deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# base image  
+FROM python:3.12.3
+
+# setup environment variable
+ENV DockerHOME=/home/ilkin/AssanStp-Django-Docker
+
+# set work directory
+RUN mkdir -p $DockerHOME
+
+# where your code lives
+WORKDIR $DockerHOME
+
+# set environment variables
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1  
+
+# install dependencies
+RUN pip install --upgrade pip  
+
+# copy whole project to your docker home directory.
+COPY . $DockerHOME
+
+# run this command to install all dependencies
+RUN pip install -r requirements.txt
+
+# run this command to makemigrations
+RUN python manage.py makemigrations
+RUN python manage.py migrate
+
+# port where the Django app runs
+EXPOSE 8000
+
+# start server
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]


### PR DESCRIPTION
- Created a `Dockerfile` to containerize the Django application.
- Set up a Python 3.12.3 environment and installed project dependencies.
- Configured the Docker container to run Django migrations and start the server on port 8000.