### PR TITLE
Add `django-cors-headers` to `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 asgiref==3.8.1
 bidict==0.23.1
 Django==5.0.7
+django-cors-headers==4.4.0
 django-filter==24.3
 djangorestframework==3.15.2
 djangorestframework-simplejwt==5.3.1


### PR DESCRIPTION
- Added `django-cors-headers==4.4.0` to the dependencies.
- Ensures handling of Cross-Origin Resource Sharing (CORS) in Django applications.